### PR TITLE
Update github repo link in the footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -31,7 +31,7 @@ const Footer: React.FunctionComponent<Props> = (props: Props) => {
                 onClick={() => window.location.href = "/"} onMouseEnter={() => setLogoHover(true)} onMouseLeave={() => setLogoHover(false)}/>
                 <p className="footer-text">Listen to soft loli breathing and moaning. <br/>Have a good time sleeping!</p>
                 <p className="footer-text active" onClick={download}>Download</p>
-                <p className="footer-text active" onClick={() => window.open("https://github.com/Tenpi/lolisleep.moe", "__blank")}>Github</p>
+                <p className="footer-text active" onClick={() => window.open("https://github.com/LubomirPacheliev/lolisleep.moe", "__blank")}>Github</p>
                 <p className="footer-text-small">Copyright © {new Date().getFullYear()} Tenpi</p>
             </div>
             <img src={laffey} className="laffey" width="240" height="288"/>


### PR DESCRIPTION
**This pull request makes the following changes**

- Update the github repo link in the footer from https://github.com/Tenpi/lolisleep.moe to https://github.com/LubomirPacheliev/lolisleep.moe

**Why?**

This ~~art~~ needs recognition and the fact that the website doesn't point to the active repo doesn't help

